### PR TITLE
Bring up to speed with current webpack-4 jsonpScript

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ class RetryChunkLoadPlugin {
     compiler.hooks.compilation.tap(pluginName, compilation => {
       const { mainTemplate } = compilation;
       if (mainTemplate.hooks.jsonpScript) {
-        // Adapted from https://github.com/webpack/webpack/blob/c74bee9cef6cd733ccf64037c3d3e010d4413082/lib/web/JsonpMainTemplatePlugin.js#L141-L203
+        // Adapted from https://github.com/webpack/webpack/blob/11e94dd2d0a8d8baae75e715ff8a69f27a9e3014/lib/web/JsonpMainTemplatePlugin.js#L145-L210
         mainTemplate.hooks.jsonpScript.tap(pluginName, () => {
           const {
             crossOriginLoading,
@@ -32,6 +32,8 @@ class RetryChunkLoadPlugin {
             : '"cache-bust=true"';
 
           const script = `
+          // create error before stack unwound to get useful stacktrace later
+          var error = new Error();
           function loadScript(src, retries) {
      
             var script = document.createElement('script');
@@ -58,7 +60,7 @@ class RetryChunkLoadPlugin {
                   if (retries === 0) {
                     var errorType = event && (event.type === 'load' ? 'missing' : event.type);
                     var realSrc = event && event.target && event.target.src;
-                    var error = new Error('Loading chunk ' + chunkId + ' failed.\\n(' + errorType + ': ' + realSrc + ')');
+                    error.message = 'Loading chunk ' + chunkId + ' failed.\\n(' + errorType + ': ' + realSrc + ')';
                     error.type = errorType;
                     error.request = realSrc;
                     chunk[1](error);

--- a/src/index.js
+++ b/src/index.js
@@ -61,6 +61,7 @@ class RetryChunkLoadPlugin {
                     var errorType = event && (event.type === 'load' ? 'missing' : event.type);
                     var realSrc = event && event.target && event.target.src;
                     error.message = 'Loading chunk ' + chunkId + ' failed.\\n(' + errorType + ': ' + realSrc + ')';
+                    error.name = 'ChunkLoadError';
                     error.type = errorType;
                     error.request = realSrc;
                     chunk[1](error);

--- a/test/integration/__snapshots__/test.js.snap
+++ b/test/integration/__snapshots__/test.js.snap
@@ -95,6 +95,8 @@ exports[`override the default jsonp script 1`] = `
 /******/ 				promises.push(installedChunkData[2] = promise);
 /******/
 /******/ 				// start chunk loading
+/******/ 				// create error before stack unwound to get useful stacktrace later
+/******/ 				var error = new Error();
 /******/ 				function loadScript(src, retries) {
 /******/ 				  var script = document.createElement('script');
 /******/ 				  var onScriptComplete;
@@ -117,15 +119,14 @@ exports[`override the default jsonp script 1`] = `
 /******/ 				          var errorType =
 /******/ 				            event && (event.type === 'load' ? 'missing' : event.type);
 /******/ 				          var realSrc = event && event.target && event.target.src;
-/******/ 				          var error = new Error(
+/******/ 				          error.message =
 /******/ 				            'Loading chunk ' +
-/******/ 				              chunkId +
-/******/ 				              ' failed.\\\\n(' +
-/******/ 				              errorType +
-/******/ 				              ': ' +
-/******/ 				              realSrc +
-/******/ 				              ')'
-/******/ 				          );
+/******/ 				            chunkId +
+/******/ 				            ' failed.\\\\n(' +
+/******/ 				            errorType +
+/******/ 				            ': ' +
+/******/ 				            realSrc +
+/******/ 				            ')';
 /******/ 				          error.type = errorType;
 /******/ 				          error.request = realSrc;
 /******/ 				          chunk[1](error);

--- a/test/integration/__snapshots__/test.js.snap
+++ b/test/integration/__snapshots__/test.js.snap
@@ -127,6 +127,7 @@ exports[`override the default jsonp script 1`] = `
 /******/ 				            ': ' +
 /******/ 				            realSrc +
 /******/ 				            ')';
+/******/ 				          error.name = 'ChunkLoadError';
 /******/ 				          error.type = errorType;
 /******/ 				          error.request = realSrc;
 /******/ 				          chunk[1](error);


### PR DESCRIPTION
- provide useful stacktrace on chunk loading failure
- add name property to error thrown on chunk load failure