### PR TITLE
feat: add support for multiple retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ plugins: [
     // if not set will default to appending the string `?cache-bust=true`
     cacheBust: `function() {
       return Date.now();
-    }`
+    }`,
+    // optional value to set the maximum number of retries to load the chunk. Default is 1
+    maxRetries: 5
   })
 ];
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,7 @@ class RetryChunkLoadPlugin {
                     installedChunks[chunkId] = undefined;
                   } else {
                     var cacheBust = ${getCacheBustString()};
-                    var retryScript = loadScript(src + '?' + cacheBust, (retries-1));
+                    var retryScript = loadScript(jsonpScriptSrc(chunkId) + '?' + cacheBust, (retries-1));
                     document.head.appendChild(retryScript);
                   }
                 } else {

--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,7 @@ class RetryChunkLoadPlugin {
                     installedChunks[chunkId] = undefined;
                   } else {
                     var cacheBust = ${getCacheBustString()};
-                    var retryScript = loadScript(src + '?' + cacheBust, 0);
+                    var retryScript = loadScript(src + '?' + cacheBust, (retries-1));
                     document.head.appendChild(retryScript);
                   }
                 } else {

--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,8 @@ class RetryChunkLoadPlugin {
           function loadScript(src, retries) {
 
             var script = document.createElement('script');
+            var retryAttempt = ${maxRetries} - retries + 1;
+            var retryAttemptString = '&retryAttempt=' + retryAttempt;
             var onScriptComplete;
             ${
               jsonpScriptType
@@ -75,7 +77,7 @@ class RetryChunkLoadPlugin {
                     chunk[1](error);
                     installedChunks[chunkId] = undefined;
                   } else {
-                    var cacheBust = ${getCacheBustString()};
+                    var cacheBust = ${getCacheBustString()} + retryAttemptString;
                     var retryScript = loadScript(jsonpScriptSrc(chunkId) + '?' + cacheBust, (retries-1));
                     document.head.appendChild(retryScript);
                   }

--- a/src/index.js
+++ b/src/index.js
@@ -32,9 +32,12 @@ class RetryChunkLoadPlugin {
           `
               : '"cache-bust=true"';
 
-          const maxRetries = Number.isInteger(Number(this.options.maxRetries))
-            ? Number(this.options.maxRetries)
-            : 1;
+          const maxRetryValueFromOptions = Number(this.options.maxRetries);
+          const maxRetries =
+            Number.isInteger(maxRetryValueFromOptions) &&
+            maxRetryValueFromOptions > 0
+              ? maxRetryValueFromOptions
+              : 1;
 
           const script = `
           // create error before stack unwound to get useful stacktrace later

--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,7 @@ class RetryChunkLoadPlugin {
             return script;
           }
           
-          var script = loadScript(jsonpScriptSrc(chunkId), maxRetries);
+          var script = loadScript(jsonpScriptSrc(chunkId), ${maxRetries});
         `;
 
           return prettier.format(script, {

--- a/test/e2e/server.js
+++ b/test/e2e/server.js
@@ -5,7 +5,7 @@ const app = express();
 const port = 3000;
 
 app.get('/0.js', (req, res, next) => {
-  if (req.query['cache-bust'] === 'true') {
+  if (req.query['cache-bust'] === 'true' && req.query['retryAttempt'] === '5') {
     next();
   } else {
     res.status(500).send('fail');

--- a/test/e2e/webpack.config.js
+++ b/test/e2e/webpack.config.js
@@ -9,5 +9,10 @@ module.exports = {
     path: path.join(__dirname, 'dist')
   },
   mode: 'development',
-  plugins: [new HtmlWebpackPlugin(), new RetryChunkLoadPlugin()]
+  plugins: [
+    new HtmlWebpackPlugin(),
+    new RetryChunkLoadPlugin({
+      maxRetries: 5
+    })
+  ]
 };

--- a/test/integration/__snapshots__/test.js.snap
+++ b/test/integration/__snapshots__/test.js.snap
@@ -99,6 +99,8 @@ exports[`override the default jsonp script 1`] = `
 /******/ 				var error = new Error();
 /******/ 				function loadScript(src, retries) {
 /******/ 				  var script = document.createElement('script');
+/******/ 				  var retryAttempt = 1 - retries + 1;
+/******/ 				  var retryAttemptString = '&retryAttempt=' + retryAttempt;
 /******/ 				  var onScriptComplete;
 /******/
 /******/ 				  script.charset = 'utf-8';
@@ -133,7 +135,7 @@ exports[`override the default jsonp script 1`] = `
 /******/ 				          chunk[1](error);
 /******/ 				          installedChunks[chunkId] = undefined;
 /******/ 				        } else {
-/******/ 				          var cacheBust = 'cache-bust=true';
+/******/ 				          var cacheBust = 'cache-bust=true' + retryAttemptString;
 /******/ 				          var retryScript = loadScript(
 /******/ 				            jsonpScriptSrc(chunkId) + '?' + cacheBust,
 /******/ 				            retries - 1

--- a/test/integration/__snapshots__/test.js.snap
+++ b/test/integration/__snapshots__/test.js.snap
@@ -134,7 +134,7 @@ exports[`override the default jsonp script 1`] = `
 /******/ 				          installedChunks[chunkId] = undefined;
 /******/ 				        } else {
 /******/ 				          var cacheBust = 'cache-bust=true';
-/******/ 				          var retryScript = loadScript(src + '?' + cacheBust, 0);
+/******/ 				          var retryScript = loadScript(src + '?' + cacheBust, retries - 1);
 /******/ 				          document.head.appendChild(retryScript);
 /******/ 				        }
 /******/ 				      } else {

--- a/test/integration/__snapshots__/test.js.snap
+++ b/test/integration/__snapshots__/test.js.snap
@@ -134,7 +134,10 @@ exports[`override the default jsonp script 1`] = `
 /******/ 				          installedChunks[chunkId] = undefined;
 /******/ 				        } else {
 /******/ 				          var cacheBust = 'cache-bust=true';
-/******/ 				          var retryScript = loadScript(src + '?' + cacheBust, retries - 1);
+/******/ 				          var retryScript = loadScript(
+/******/ 				            jsonpScriptSrc(chunkId) + '?' + cacheBust,
+/******/ 				            retries - 1
+/******/ 				          );
 /******/ 				          document.head.appendChild(retryScript);
 /******/ 				        }
 /******/ 				      } else {


### PR DESCRIPTION
**Summary**
I have added support for multiple retries via a config parameter `maxRetries` whose default value is 1.

This PR has the following changes:

1. Added support for multiple retries via `maxRetries` option.
2. Default value of `maxRetries` is 1.
3. Since each of the retry attempts should have a unique URL, the cacheBusting URL is changed on each retry attempt. This is done by calling the function`getCacheBustString` every time.
4. Have updated the README with the instructions to use this option.

**Update**

1.  Have updated the e2e to testing suite to verify the behavior with `maxRetries`.
2. We also append `&retryAttempt=attemptValue` in the query string to track retryAttempt.

This closes #4 