### PR TITLE
feat: add option to only retry loading specific chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,10 @@ plugins: [
       return Date.now();
     }`,
     // optional value to set the maximum number of retries to load the chunk. Default is 1
-    maxRetries: 5
+    maxRetries: 5,
+    // optional list of chunks to which retry script should be injected
+    // if not set will add retry script to all chunks that have webpack script loading
+    chunks: ['chunkName']
   })
 ];
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1274,9 +1274,9 @@
       }
     },
     "acorn": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
       "dev": true
     },
     "acorn-globals": {
@@ -1290,9 +1290,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
-          "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
           "dev": true
         }
       }
@@ -4029,14 +4029,6 @@
         "acorn": "^7.1.0",
         "acorn-jsx": "^5.1.0",
         "eslint-visitor-keys": "^1.1.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-          "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
-          "dev": true
-        }
       }
     },
     "esprima": {
@@ -12332,9 +12324,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
-          "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
           "dev": true
         },
         "big.js": {

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ class RetryChunkLoadPlugin {
                   if (retries === 0) {
                     var errorType = event && (event.type === 'load' ? 'missing' : event.type);
                     var realSrc = event && event.target && event.target.src;
-                    error.message = 'Loading chunk ' + chunkId + ' failed.\\n(' + errorType + ': ' + realSrc + ')';
+                    error.message = 'Loading chunk ' + chunkId + ' failed after ${maxRetries} retries.\\n(' + errorType + ': ' + realSrc + ')';
                     error.name = 'ChunkLoadError';
                     error.type = errorType;
                     error.request = realSrc;

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ class RetryChunkLoadPlugin {
       const { mainTemplate } = compilation;
       if (mainTemplate.hooks.jsonpScript) {
         // Adapted from https://github.com/webpack/webpack/blob/11e94dd2d0a8d8baae75e715ff8a69f27a9e3014/lib/web/JsonpMainTemplatePlugin.js#L145-L210
-        mainTemplate.hooks.jsonpScript.tap(pluginName, () => {
+        mainTemplate.hooks.jsonpScript.tap(pluginName, (_, chunk) => {
           const {
             crossOriginLoading,
             chunkLoadTimeout,
@@ -39,7 +39,7 @@ class RetryChunkLoadPlugin {
               ? maxRetryValueFromOptions
               : 1;
 
-          const script = `
+          const scriptWithRetry = `
           // create error before stack unwound to get useful stacktrace later
           var error = new Error();
           function loadScript(src, retries) {
@@ -95,6 +95,51 @@ class RetryChunkLoadPlugin {
 
           var script = loadScript(jsonpScriptSrc(chunkId), ${maxRetries});
         `;
+
+          const scriptWithoutRetry = `
+          var script = document.createElement('script');
+          var onScriptComplete;
+          ${
+            jsonpScriptType
+              ? `script.type = ${JSON.stringify(jsonpScriptType)};`
+              : ''
+          }
+          script.charset = 'utf-8';
+          script.timeout = ${chunkLoadTimeout / 1000};
+          if (${mainTemplate.requireFn}.nc) {
+            script.setAttribute("nonce", ${mainTemplate.requireFn}.nc);
+          }
+          script.src = jsonpScriptSrc(chunkId);
+          ${crossOriginLoading ? crossOriginScript : ''}
+          onScriptComplete = function (event) {
+            // avoid mem leaks in IE.
+            script.onerror = script.onload = null;
+            clearTimeout(timeout);
+            var chunk = installedChunks[chunkId];
+            if (chunk !== 0) {
+              if (chunk) {
+                var errorType = event && (event.type === 'load' ? 'missing' : event.type);
+                var realSrc = event && event.target && event.target.src;
+                error.message = 'Loading chunk ' + chunkId + ' failed.\\n(' + errorType + ': ' + realSrc + ')';
+                error.name = 'ChunkLoadError';
+                error.type = errorType;
+                error.request = realSrc;
+                chunk[1](error);
+              }
+              installedChunks[chunkId] = undefined;
+            }
+          };
+          var timeout = setTimeout(function(){
+            onScriptComplete({ type: 'timeout', target: script });
+          }, ${chunkLoadTimeout});
+          script.onerror = script.onload = onScriptComplete;
+        `;
+
+          const currentChunkName = chunk.name;
+          const addRetryCode =
+            !this.options.chunks ||
+            this.options.chunks.includes(currentChunkName);
+          const script = addRetryCode ? scriptWithRetry : scriptWithoutRetry;
 
           return prettier.format(script, {
             singleQuote: true,

--- a/test/integration/__snapshots__/test.js.snap
+++ b/test/integration/__snapshots__/test.js.snap
@@ -354,6 +354,8 @@ exports[`override the default jsonp script without retry 1`] = `
 /******/ 				}
 /******/ 				script.src = jsonpScriptSrc(chunkId);
 /******/
+/******/ 				// create error before stack unwound to get useful stacktrace later
+/******/ 				var error = new Error();
 /******/ 				onScriptComplete = function(event) {
 /******/ 				  // avoid mem leaks in IE.
 /******/ 				  script.onerror = script.onload = null;

--- a/test/integration/__snapshots__/test.js.snap
+++ b/test/integration/__snapshots__/test.js.snap
@@ -248,3 +248,231 @@ run();
 
 /******/ });"
 `;
+
+exports[`override the default jsonp script without retry 1`] = `
+"/******/ (function(modules) { // webpackBootstrap
+/******/ 	// install a JSONP callback for chunk loading
+/******/ 	function webpackJsonpCallback(data) {
+/******/ 		var chunkIds = data[0];
+/******/ 		var moreModules = data[1];
+/******/
+/******/
+/******/ 		// add \\"moreModules\\" to the modules object,
+/******/ 		// then flag all \\"chunkIds\\" as loaded and fire callback
+/******/ 		var moduleId, chunkId, i = 0, resolves = [];
+/******/ 		for(;i < chunkIds.length; i++) {
+/******/ 			chunkId = chunkIds[i];
+/******/ 			if(Object.prototype.hasOwnProperty.call(installedChunks, chunkId) && installedChunks[chunkId]) {
+/******/ 				resolves.push(installedChunks[chunkId][0]);
+/******/ 			}
+/******/ 			installedChunks[chunkId] = 0;
+/******/ 		}
+/******/ 		for(moduleId in moreModules) {
+/******/ 			if(Object.prototype.hasOwnProperty.call(moreModules, moduleId)) {
+/******/ 				modules[moduleId] = moreModules[moduleId];
+/******/ 			}
+/******/ 		}
+/******/ 		if(parentJsonpFunction) parentJsonpFunction(data);
+/******/
+/******/ 		while(resolves.length) {
+/******/ 			resolves.shift()();
+/******/ 		}
+/******/
+/******/ 	};
+/******/
+/******/
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// object to store loaded and loading chunks
+/******/ 	// undefined = chunk not loaded, null = chunk preloaded/prefetched
+/******/ 	// Promise = chunk loading, 0 = chunk loaded
+/******/ 	var installedChunks = {
+/******/ 		\\"main\\": 0
+/******/ 	};
+/******/
+/******/
+/******/
+/******/ 	// script path function
+/******/ 	function jsonpScriptSrc(chunkId) {
+/******/ 		return __webpack_require__.p + \\"\\" + ({}[chunkId]||chunkId) + \\".js\\"
+/******/ 	}
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/ 	// This file contains only the entry chunk.
+/******/ 	// The chunk loading function for additional chunks
+/******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
+/******/ 		var promises = [];
+/******/
+/******/
+/******/ 		// JSONP chunk loading for javascript
+/******/
+/******/ 		var installedChunkData = installedChunks[chunkId];
+/******/ 		if(installedChunkData !== 0) { // 0 means \\"already installed\\".
+/******/
+/******/ 			// a Promise means \\"currently loading\\".
+/******/ 			if(installedChunkData) {
+/******/ 				promises.push(installedChunkData[2]);
+/******/ 			} else {
+/******/ 				// setup Promise in chunk cache
+/******/ 				var promise = new Promise(function(resolve, reject) {
+/******/ 					installedChunkData = installedChunks[chunkId] = [resolve, reject];
+/******/ 				});
+/******/ 				promises.push(installedChunkData[2] = promise);
+/******/
+/******/ 				// start chunk loading
+/******/ 				var script = document.createElement('script');
+/******/ 				var onScriptComplete;
+/******/
+/******/ 				script.charset = 'utf-8';
+/******/ 				script.timeout = 120;
+/******/ 				if (__webpack_require__.nc) {
+/******/ 				  script.setAttribute('nonce', __webpack_require__.nc);
+/******/ 				}
+/******/ 				script.src = jsonpScriptSrc(chunkId);
+/******/
+/******/ 				onScriptComplete = function(event) {
+/******/ 				  // avoid mem leaks in IE.
+/******/ 				  script.onerror = script.onload = null;
+/******/ 				  clearTimeout(timeout);
+/******/ 				  var chunk = installedChunks[chunkId];
+/******/ 				  if (chunk !== 0) {
+/******/ 				    if (chunk) {
+/******/ 				      var errorType = event && (event.type === 'load' ? 'missing' : event.type);
+/******/ 				      var realSrc = event && event.target && event.target.src;
+/******/ 				      error.message =
+/******/ 				        'Loading chunk ' +
+/******/ 				        chunkId +
+/******/ 				        ' failed.\\\\n(' +
+/******/ 				        errorType +
+/******/ 				        ': ' +
+/******/ 				        realSrc +
+/******/ 				        ')';
+/******/ 				      error.name = 'ChunkLoadError';
+/******/ 				      error.type = errorType;
+/******/ 				      error.request = realSrc;
+/******/ 				      chunk[1](error);
+/******/ 				    }
+/******/ 				    installedChunks[chunkId] = undefined;
+/******/ 				  }
+/******/ 				};
+/******/ 				var timeout = setTimeout(function() {
+/******/ 				  onScriptComplete({ type: 'timeout', target: script });
+/******/ 				}, 120000);
+/******/ 				script.onerror = script.onload = onScriptComplete;
+/******/ 				document.head.appendChild(script);
+/******/ 			}
+/******/ 		}
+/******/ 		return Promise.all(promises);
+/******/ 	};
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = \\"\\";
+/******/
+/******/ 	// on error function for async loading
+/******/ 	__webpack_require__.oe = function(err) { console.error(err); throw err; };
+/******/
+/******/ 	var jsonpArray = window[\\"webpackJsonp\\"] = window[\\"webpackJsonp\\"] || [];
+/******/ 	var oldJsonpFunction = jsonpArray.push.bind(jsonpArray);
+/******/ 	jsonpArray.push = webpackJsonpCallback;
+/******/ 	jsonpArray = jsonpArray.slice();
+/******/ 	for(var i = 0; i < jsonpArray.length; i++) webpackJsonpCallback(jsonpArray[i]);
+/******/ 	var parentJsonpFunction = oldJsonpFunction;
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = \\"./test/integration/fixtures/index.js\\");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ \\"./test/integration/fixtures/index.js\\":
+/*!********************************************!*\\\\
+  !*** ./test/integration/fixtures/index.js ***!
+  \\\\********************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+async function run() {
+  console.log(await __webpack_require__.e(/*! import() */ 0).then(__webpack_require__.bind(null, /*! ./async */ \\"./test/integration/fixtures/async.js\\")));
+}
+
+run();
+
+
+/***/ })
+
+/******/ });"
+`;

--- a/test/integration/__snapshots__/test.js.snap
+++ b/test/integration/__snapshots__/test.js.snap
@@ -124,7 +124,7 @@ exports[`override the default jsonp script 1`] = `
 /******/ 				          error.message =
 /******/ 				            'Loading chunk ' +
 /******/ 				            chunkId +
-/******/ 				            ' failed.\\\\n(' +
+/******/ 				            ' failed after 1 retries.\\\\n(' +
 /******/ 				            errorType +
 /******/ 				            ': ' +
 /******/ 				            realSrc +

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -9,3 +9,10 @@ test('override the default jsonp script', async () => {
   const mainContents = fs.readFileSync(mainOutputFile).toString();
   expect(mainContents).toMatchSnapshot();
 });
+
+test('override the default jsonp script without retry', async () => {
+  const { result, fs } = webpack({ chunks: [] });
+  await result;
+  const mainContents = fs.readFileSync(mainOutputFile).toString();
+  expect(mainContents).toMatchSnapshot();
+});


### PR DESCRIPTION
1) Added retry info to error message.

2) Added a new option 'chunks' for list of chunknames. If specified, retry code will only be injected to those list of chunks. Otherwise, it is injected to all chunks.