### PR TITLE
fix: add support for entry chunks with no imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-retry-chunk-load-plugin",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A webpack plugin to retry loading of chunks that failed to load",
   "main": "src/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-retry-chunk-load-plugin",
-  "version": "2.0.3",
+  "version": "2.0.2",
   "description": "A webpack plugin to retry loading of chunks that failed to load",
   "main": "src/index.js",
   "directories": {

--- a/test/integration/__snapshots__/test.js.snap
+++ b/test/integration/__snapshots__/test.js.snap
@@ -160,39 +160,41 @@ exports[`inserts last resort script into the code handling failure after all ret
 /******/ 	})();
 /******/ 	
 /******/ 	/* webpack/runtime/compat */
-/******/ 	var oldGetScript = __webpack_require__.u;
-/******/ 	var oldLoadScript = __webpack_require__.e;
-/******/ 	var queryMap = new Map();
-/******/ 	var countMap = new Map();
-/******/ 	var maxRetries = 1;
-/******/ 	__webpack_require__.u = function (chunkId) {
-/******/ 	  var result = oldGetScript(chunkId);
-/******/ 	  return result + (queryMap.has(chunkId) ? '?' + queryMap.get(chunkId) : '');
-/******/ 	};
-/******/ 	__webpack_require__.e = function (chunkId) {
-/******/ 	  var result = oldLoadScript(chunkId);
-/******/ 	  return result.catch(function (error) {
-/******/ 	    var retries = countMap.has(chunkId) ? countMap.get(chunkId) : 1;
-/******/ 	    if (retries < 1) {
-/******/ 	      var realSrc = oldGetScript(chunkId);
-/******/ 	      error.message =
-/******/ 	        'Loading chunk ' +
-/******/ 	        chunkId +
-/******/ 	        ' failed after 1 retries.\\\\n(' +
-/******/ 	        realSrc +
-/******/ 	        ')';
-/******/ 	      error.request = realSrc;
-/******/ 	      window.location.href = '/500.html';
-/******/ 	      throw error;
-/******/ 	    }
-/******/ 	    var retryAttempt = 1 - retries + 1;
-/******/ 	    var retryAttemptString = '&retry-attempt=' + retryAttempt;
-/******/ 	    var cacheBust = 'cache-bust=true' + retryAttemptString;
-/******/ 	    queryMap.set(chunkId, cacheBust);
-/******/ 	    countMap.set(chunkId, retries - 1);
-/******/ 	    return __webpack_require__.e(chunkId);
-/******/ 	  });
-/******/ 	};
+/******/ 	if (typeof __webpack_require__ !== 'undefined') {
+/******/ 	  var oldGetScript = __webpack_require__.u;
+/******/ 	  var oldLoadScript = __webpack_require__.e;
+/******/ 	  var queryMap = new Map();
+/******/ 	  var countMap = new Map();
+/******/ 	  var maxRetries = 1;
+/******/ 	  __webpack_require__.u = function (chunkId) {
+/******/ 	    var result = oldGetScript(chunkId);
+/******/ 	    return result + (queryMap.has(chunkId) ? '?' + queryMap.get(chunkId) : '');
+/******/ 	  };
+/******/ 	  __webpack_require__.e = function (chunkId) {
+/******/ 	    var result = oldLoadScript(chunkId);
+/******/ 	    return result.catch(function (error) {
+/******/ 	      var retries = countMap.has(chunkId) ? countMap.get(chunkId) : 1;
+/******/ 	      if (retries < 1) {
+/******/ 	        var realSrc = oldGetScript(chunkId);
+/******/ 	        error.message =
+/******/ 	          'Loading chunk ' +
+/******/ 	          chunkId +
+/******/ 	          ' failed after 1 retries.\\\\n(' +
+/******/ 	          realSrc +
+/******/ 	          ')';
+/******/ 	        error.request = realSrc;
+/******/ 	        window.location.href = '/500.html';
+/******/ 	        throw error;
+/******/ 	      }
+/******/ 	      var retryAttempt = 1 - retries + 1;
+/******/ 	      var retryAttemptString = '&retry-attempt=' + retryAttempt;
+/******/ 	      var cacheBust = 'cache-bust=true' + retryAttemptString;
+/******/ 	      queryMap.set(chunkId, cacheBust);
+/******/ 	      countMap.set(chunkId, retries - 1);
+/******/ 	      return __webpack_require__.e(chunkId);
+/******/ 	    });
+/******/ 	  };
+/******/ 	}
 /******/ 	/* webpack/runtime/jsonp chunk loading */
 /******/ 	(() => {
 /******/ 		// no baseURI
@@ -463,38 +465,40 @@ exports[`override the default jsonp script 1`] = `
 /******/ 	})();
 /******/ 	
 /******/ 	/* webpack/runtime/compat */
-/******/ 	var oldGetScript = __webpack_require__.u;
-/******/ 	var oldLoadScript = __webpack_require__.e;
-/******/ 	var queryMap = new Map();
-/******/ 	var countMap = new Map();
-/******/ 	var maxRetries = 1;
-/******/ 	__webpack_require__.u = function (chunkId) {
-/******/ 	  var result = oldGetScript(chunkId);
-/******/ 	  return result + (queryMap.has(chunkId) ? '?' + queryMap.get(chunkId) : '');
-/******/ 	};
-/******/ 	__webpack_require__.e = function (chunkId) {
-/******/ 	  var result = oldLoadScript(chunkId);
-/******/ 	  return result.catch(function (error) {
-/******/ 	    var retries = countMap.has(chunkId) ? countMap.get(chunkId) : 1;
-/******/ 	    if (retries < 1) {
-/******/ 	      var realSrc = oldGetScript(chunkId);
-/******/ 	      error.message =
-/******/ 	        'Loading chunk ' +
-/******/ 	        chunkId +
-/******/ 	        ' failed after 1 retries.\\\\n(' +
-/******/ 	        realSrc +
-/******/ 	        ')';
-/******/ 	      error.request = realSrc;
-/******/ 	      throw error;
-/******/ 	    }
-/******/ 	    var retryAttempt = 1 - retries + 1;
-/******/ 	    var retryAttemptString = '&retry-attempt=' + retryAttempt;
-/******/ 	    var cacheBust = 'cache-bust=true' + retryAttemptString;
-/******/ 	    queryMap.set(chunkId, cacheBust);
-/******/ 	    countMap.set(chunkId, retries - 1);
-/******/ 	    return __webpack_require__.e(chunkId);
-/******/ 	  });
-/******/ 	};
+/******/ 	if (typeof __webpack_require__ !== 'undefined') {
+/******/ 	  var oldGetScript = __webpack_require__.u;
+/******/ 	  var oldLoadScript = __webpack_require__.e;
+/******/ 	  var queryMap = new Map();
+/******/ 	  var countMap = new Map();
+/******/ 	  var maxRetries = 1;
+/******/ 	  __webpack_require__.u = function (chunkId) {
+/******/ 	    var result = oldGetScript(chunkId);
+/******/ 	    return result + (queryMap.has(chunkId) ? '?' + queryMap.get(chunkId) : '');
+/******/ 	  };
+/******/ 	  __webpack_require__.e = function (chunkId) {
+/******/ 	    var result = oldLoadScript(chunkId);
+/******/ 	    return result.catch(function (error) {
+/******/ 	      var retries = countMap.has(chunkId) ? countMap.get(chunkId) : 1;
+/******/ 	      if (retries < 1) {
+/******/ 	        var realSrc = oldGetScript(chunkId);
+/******/ 	        error.message =
+/******/ 	          'Loading chunk ' +
+/******/ 	          chunkId +
+/******/ 	          ' failed after 1 retries.\\\\n(' +
+/******/ 	          realSrc +
+/******/ 	          ')';
+/******/ 	        error.request = realSrc;
+/******/ 	        throw error;
+/******/ 	      }
+/******/ 	      var retryAttempt = 1 - retries + 1;
+/******/ 	      var retryAttemptString = '&retry-attempt=' + retryAttempt;
+/******/ 	      var cacheBust = 'cache-bust=true' + retryAttemptString;
+/******/ 	      queryMap.set(chunkId, cacheBust);
+/******/ 	      countMap.set(chunkId, retries - 1);
+/******/ 	      return __webpack_require__.e(chunkId);
+/******/ 	    });
+/******/ 	  };
+/******/ 	}
 /******/ 	/* webpack/runtime/jsonp chunk loading */
 /******/ 	(() => {
 /******/ 		// no baseURI
@@ -1034,38 +1038,40 @@ exports[`retry loading the main chunk 1`] = `
 /******/ 	})();
 /******/ 	
 /******/ 	/* webpack/runtime/compat */
-/******/ 	var oldGetScript = __webpack_require__.u;
-/******/ 	var oldLoadScript = __webpack_require__.e;
-/******/ 	var queryMap = new Map();
-/******/ 	var countMap = new Map();
-/******/ 	var maxRetries = 1;
-/******/ 	__webpack_require__.u = function (chunkId) {
-/******/ 	  var result = oldGetScript(chunkId);
-/******/ 	  return result + (queryMap.has(chunkId) ? '?' + queryMap.get(chunkId) : '');
-/******/ 	};
-/******/ 	__webpack_require__.e = function (chunkId) {
-/******/ 	  var result = oldLoadScript(chunkId);
-/******/ 	  return result.catch(function (error) {
-/******/ 	    var retries = countMap.has(chunkId) ? countMap.get(chunkId) : 1;
-/******/ 	    if (retries < 1) {
-/******/ 	      var realSrc = oldGetScript(chunkId);
-/******/ 	      error.message =
-/******/ 	        'Loading chunk ' +
-/******/ 	        chunkId +
-/******/ 	        ' failed after 1 retries.\\\\n(' +
-/******/ 	        realSrc +
-/******/ 	        ')';
-/******/ 	      error.request = realSrc;
-/******/ 	      throw error;
-/******/ 	    }
-/******/ 	    var retryAttempt = 1 - retries + 1;
-/******/ 	    var retryAttemptString = '&retry-attempt=' + retryAttempt;
-/******/ 	    var cacheBust = 'cache-bust=true' + retryAttemptString;
-/******/ 	    queryMap.set(chunkId, cacheBust);
-/******/ 	    countMap.set(chunkId, retries - 1);
-/******/ 	    return __webpack_require__.e(chunkId);
-/******/ 	  });
-/******/ 	};
+/******/ 	if (typeof __webpack_require__ !== 'undefined') {
+/******/ 	  var oldGetScript = __webpack_require__.u;
+/******/ 	  var oldLoadScript = __webpack_require__.e;
+/******/ 	  var queryMap = new Map();
+/******/ 	  var countMap = new Map();
+/******/ 	  var maxRetries = 1;
+/******/ 	  __webpack_require__.u = function (chunkId) {
+/******/ 	    var result = oldGetScript(chunkId);
+/******/ 	    return result + (queryMap.has(chunkId) ? '?' + queryMap.get(chunkId) : '');
+/******/ 	  };
+/******/ 	  __webpack_require__.e = function (chunkId) {
+/******/ 	    var result = oldLoadScript(chunkId);
+/******/ 	    return result.catch(function (error) {
+/******/ 	      var retries = countMap.has(chunkId) ? countMap.get(chunkId) : 1;
+/******/ 	      if (retries < 1) {
+/******/ 	        var realSrc = oldGetScript(chunkId);
+/******/ 	        error.message =
+/******/ 	          'Loading chunk ' +
+/******/ 	          chunkId +
+/******/ 	          ' failed after 1 retries.\\\\n(' +
+/******/ 	          realSrc +
+/******/ 	          ')';
+/******/ 	        error.request = realSrc;
+/******/ 	        throw error;
+/******/ 	      }
+/******/ 	      var retryAttempt = 1 - retries + 1;
+/******/ 	      var retryAttemptString = '&retry-attempt=' + retryAttempt;
+/******/ 	      var cacheBust = 'cache-bust=true' + retryAttemptString;
+/******/ 	      queryMap.set(chunkId, cacheBust);
+/******/ 	      countMap.set(chunkId, retries - 1);
+/******/ 	      return __webpack_require__.e(chunkId);
+/******/ 	    });
+/******/ 	  };
+/******/ 	}
 /******/ 	/* webpack/runtime/jsonp chunk loading */
 /******/ 	(() => {
 /******/ 		// no baseURI

--- a/test/integration/fixtures/index-no-import.js
+++ b/test/integration/fixtures/index-no-import.js
@@ -1,0 +1,1 @@
+console.log('welcome to my module');


### PR DESCRIPTION
Entry chunks which do not import/require any other modules will not have __webpack_require__ defined, leading to a runtime failure. Lets protect against this by checking for the existance of __webpack_require__ before trying to use it. It is a very small amount of increased code, and may possibly be minified out (though I have not verified).

To validate that the described scenario is broken, try running the e2e test server with the included index-no-import.js. Also used this to validate my fix (no runtime error in webpack runtime).

I know it seems strange to want this retry plugin for chunks that dont have anything that would get value from it, but we have a multiple-entry-chunk project. While it is probably possible to use `chunks` (though an excludedChunks may fit a little better), I dont see any harm in providing this runtime safety check.

Closes #20 