### PR TITLE
fix: Add a semicolon to prevent problems caused by the webpack produc…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,7 @@ class RetryChunkLoadPlugin {
           }`
           );
           return (
-            source +
+            source + '\n' +
             prettier.format(script, {
               trailingComma: 'es5',
               singleQuote: true,


### PR DESCRIPTION
Add a semicolon to prevent problems caused by the webpack production environment. We have used a lot of optimized plug-ins, and have not yet located which plug-in caused it~

eg:

![image](https://user-images.githubusercontent.com/6488747/118067439-21b65180-b3d3-11eb-9670-c97993f47dc9.png)

