### PR TITLE
fix: avoid using Map to make the code es5 compatible

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,12 +78,12 @@ export class RetryChunkLoadPlugin {
             var getRetryDelay = ${getRetryDelay}
             ${RuntimeGlobals.getChunkScriptFilename} = function(chunkId){
               var result = oldGetScript(chunkId);
-              return result + (queryMap[chunkId] !== undefined ? '?' + queryMap[chunkId]  : '');
+              return result + (queryMap.hasOwnProperty(chunkId) ? '?' + queryMap[chunkId]  : '');
             };
             ${RuntimeGlobals.ensureChunk} = function(chunkId){
               var result = oldLoadScript(chunkId);
               return result.catch(function(error){
-                var retries = countMap[chunkId] !== undefined ? countMap[chunkId] : ${maxRetries};
+                var retries = countMap.hasOwnProperty(chunkId) ? countMap[chunkId] : ${maxRetries};
                 if (retries < 1) {
                   var realSrc = oldGetScript(chunkId);
                   error.message = 'Loading chunk ' + chunkId + ' failed after ${maxRetries} retries.\\n(' + realSrc + ')';

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ export class RetryChunkLoadPlugin {
             var getRetryDelay = ${getRetryDelay}
             ${RuntimeGlobals.getChunkScriptFilename} = function(chunkId){
               var result = oldGetScript(chunkId);
-              return result + (!!queryMap[chunkId] ? '?' + queryMap[chunkId]  : '');
+              return result + (queryMap[chunkId] !== undefined ? '?' + queryMap[chunkId]  : '');
             };
             ${RuntimeGlobals.ensureChunk} = function(chunkId){
               var result = oldLoadScript(chunkId);

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,17 +73,17 @@ export class RetryChunkLoadPlugin {
           if(typeof ${RuntimeGlobals.require} !== "undefined") {
             var oldGetScript = ${RuntimeGlobals.getChunkScriptFilename};
             var oldLoadScript = ${RuntimeGlobals.ensureChunk};
-            var queryMap = new Map();
-            var countMap = new Map();
+            var queryMap = {};
+            var countMap = {};
             var getRetryDelay = ${getRetryDelay}
             ${RuntimeGlobals.getChunkScriptFilename} = function(chunkId){
               var result = oldGetScript(chunkId);
-              return result + (queryMap.has(chunkId) ? '?' + queryMap.get(chunkId)  : '');
+              return result + (!!queryMap[chunkId] ? '?' + queryMap[chunkId]  : '');
             };
             ${RuntimeGlobals.ensureChunk} = function(chunkId){
               var result = oldLoadScript(chunkId);
               return result.catch(function(error){
-                var retries = countMap.has(chunkId) ? countMap.get(chunkId) : ${maxRetries};
+                var retries = countMap[chunkId] !== undefined ? countMap[chunkId] : ${maxRetries};
                 if (retries < 1) {
                   var realSrc = oldGetScript(chunkId);
                   error.message = 'Loading chunk ' + chunkId + ' failed after ${maxRetries} retries.\\n(' + realSrc + ')';
@@ -99,8 +99,8 @@ export class RetryChunkLoadPlugin {
                   setTimeout(function () {
                     var retryAttemptString = '&retry-attempt=' + retryAttempt;
                     var cacheBust = ${getCacheBustString()} + retryAttemptString;
-                    queryMap.set(chunkId, cacheBust);
-                    countMap.set(chunkId, retries - 1);
+                    queryMap[chunkId] = cacheBust;
+                    countMap[chunkId] = retries - 1;
                     resolve(${RuntimeGlobals.ensureChunk}(chunkId));
                   }, getRetryDelay(retryAttempt))
                 })

--- a/test/integration/__snapshots__/test.ts.snap
+++ b/test/integration/__snapshots__/test.ts.snap
@@ -59,7 +59,10 @@ console.log('foo loaded!');
 /******/ 	    };
 /******/ 	    __webpack_require__.u = function (chunkId) {
 /******/ 	      var result = oldGetScript(chunkId);
-/******/ 	      return result + (!!queryMap[chunkId] ? '?' + queryMap[chunkId] : '');
+/******/ 	      return (
+/******/ 	        result +
+/******/ 	        (queryMap[chunkId] !== undefined ? '?' + queryMap[chunkId] : '')
+/******/ 	      );
 /******/ 	    };
 /******/ 	    __webpack_require__.e = function (chunkId) {
 /******/ 	      var result = oldLoadScript(chunkId);
@@ -171,7 +174,10 @@ console.log('foo loaded!');
 /******/ 	    };
 /******/ 	    __webpack_require__.u = function (chunkId) {
 /******/ 	      var result = oldGetScript(chunkId);
-/******/ 	      return result + (!!queryMap[chunkId] ? '?' + queryMap[chunkId] : '');
+/******/ 	      return (
+/******/ 	        result +
+/******/ 	        (queryMap[chunkId] !== undefined ? '?' + queryMap[chunkId] : '')
+/******/ 	      );
 /******/ 	    };
 /******/ 	    __webpack_require__.e = function (chunkId) {
 /******/ 	      var result = oldLoadScript(chunkId);
@@ -282,7 +288,10 @@ console.log('foo loaded!');
 /******/ 	    };
 /******/ 	    __webpack_require__.u = function (chunkId) {
 /******/ 	      var result = oldGetScript(chunkId);
-/******/ 	      return result + (!!queryMap[chunkId] ? '?' + queryMap[chunkId] : '');
+/******/ 	      return (
+/******/ 	        result +
+/******/ 	        (queryMap[chunkId] !== undefined ? '?' + queryMap[chunkId] : '')
+/******/ 	      );
 /******/ 	    };
 /******/ 	    __webpack_require__.e = function (chunkId) {
 /******/ 	      var result = oldLoadScript(chunkId);
@@ -393,7 +402,10 @@ console.log('foo loaded!');
 /******/ 	    };
 /******/ 	    __webpack_require__.u = function (chunkId) {
 /******/ 	      var result = oldGetScript(chunkId);
-/******/ 	      return result + (!!queryMap[chunkId] ? '?' + queryMap[chunkId] : '');
+/******/ 	      return (
+/******/ 	        result +
+/******/ 	        (queryMap[chunkId] !== undefined ? '?' + queryMap[chunkId] : '')
+/******/ 	      );
 /******/ 	    };
 /******/ 	    __webpack_require__.e = function (chunkId) {
 /******/ 	      var result = oldLoadScript(chunkId);
@@ -570,7 +582,10 @@ console.log('foo loaded!');
 /******/ 	    };
 /******/ 	    __webpack_require__.u = function (chunkId) {
 /******/ 	      var result = oldGetScript(chunkId);
-/******/ 	      return result + (!!queryMap[chunkId] ? '?' + queryMap[chunkId] : '');
+/******/ 	      return (
+/******/ 	        result +
+/******/ 	        (queryMap[chunkId] !== undefined ? '?' + queryMap[chunkId] : '')
+/******/ 	      );
 /******/ 	    };
 /******/ 	    __webpack_require__.e = function (chunkId) {
 /******/ 	      var result = oldLoadScript(chunkId);

--- a/test/integration/__snapshots__/test.ts.snap
+++ b/test/integration/__snapshots__/test.ts.snap
@@ -61,13 +61,13 @@ console.log('foo loaded!');
 /******/ 	      var result = oldGetScript(chunkId);
 /******/ 	      return (
 /******/ 	        result +
-/******/ 	        (queryMap[chunkId] !== undefined ? '?' + queryMap[chunkId] : '')
+/******/ 	        (queryMap.hasOwnProperty(chunkId) ? '?' + queryMap[chunkId] : '')
 /******/ 	      );
 /******/ 	    };
 /******/ 	    __webpack_require__.e = function (chunkId) {
 /******/ 	      var result = oldLoadScript(chunkId);
 /******/ 	      return result.catch(function (error) {
-/******/ 	        var retries = countMap[chunkId] !== undefined ? countMap[chunkId] : 1;
+/******/ 	        var retries = countMap.hasOwnProperty(chunkId) ? countMap[chunkId] : 1;
 /******/ 	        if (retries < 1) {
 /******/ 	          var realSrc = oldGetScript(chunkId);
 /******/ 	          error.message =
@@ -176,13 +176,13 @@ console.log('foo loaded!');
 /******/ 	      var result = oldGetScript(chunkId);
 /******/ 	      return (
 /******/ 	        result +
-/******/ 	        (queryMap[chunkId] !== undefined ? '?' + queryMap[chunkId] : '')
+/******/ 	        (queryMap.hasOwnProperty(chunkId) ? '?' + queryMap[chunkId] : '')
 /******/ 	      );
 /******/ 	    };
 /******/ 	    __webpack_require__.e = function (chunkId) {
 /******/ 	      var result = oldLoadScript(chunkId);
 /******/ 	      return result.catch(function (error) {
-/******/ 	        var retries = countMap[chunkId] !== undefined ? countMap[chunkId] : 1;
+/******/ 	        var retries = countMap.hasOwnProperty(chunkId) ? countMap[chunkId] : 1;
 /******/ 	        if (retries < 1) {
 /******/ 	          var realSrc = oldGetScript(chunkId);
 /******/ 	          error.message =
@@ -290,13 +290,13 @@ console.log('foo loaded!');
 /******/ 	      var result = oldGetScript(chunkId);
 /******/ 	      return (
 /******/ 	        result +
-/******/ 	        (queryMap[chunkId] !== undefined ? '?' + queryMap[chunkId] : '')
+/******/ 	        (queryMap.hasOwnProperty(chunkId) ? '?' + queryMap[chunkId] : '')
 /******/ 	      );
 /******/ 	    };
 /******/ 	    __webpack_require__.e = function (chunkId) {
 /******/ 	      var result = oldLoadScript(chunkId);
 /******/ 	      return result.catch(function (error) {
-/******/ 	        var retries = countMap[chunkId] !== undefined ? countMap[chunkId] : 1;
+/******/ 	        var retries = countMap.hasOwnProperty(chunkId) ? countMap[chunkId] : 1;
 /******/ 	        if (retries < 1) {
 /******/ 	          var realSrc = oldGetScript(chunkId);
 /******/ 	          error.message =
@@ -404,13 +404,13 @@ console.log('foo loaded!');
 /******/ 	      var result = oldGetScript(chunkId);
 /******/ 	      return (
 /******/ 	        result +
-/******/ 	        (queryMap[chunkId] !== undefined ? '?' + queryMap[chunkId] : '')
+/******/ 	        (queryMap.hasOwnProperty(chunkId) ? '?' + queryMap[chunkId] : '')
 /******/ 	      );
 /******/ 	    };
 /******/ 	    __webpack_require__.e = function (chunkId) {
 /******/ 	      var result = oldLoadScript(chunkId);
 /******/ 	      return result.catch(function (error) {
-/******/ 	        var retries = countMap[chunkId] !== undefined ? countMap[chunkId] : 1;
+/******/ 	        var retries = countMap.hasOwnProperty(chunkId) ? countMap[chunkId] : 1;
 /******/ 	        if (retries < 1) {
 /******/ 	          var realSrc = oldGetScript(chunkId);
 /******/ 	          error.message =
@@ -584,13 +584,13 @@ console.log('foo loaded!');
 /******/ 	      var result = oldGetScript(chunkId);
 /******/ 	      return (
 /******/ 	        result +
-/******/ 	        (queryMap[chunkId] !== undefined ? '?' + queryMap[chunkId] : '')
+/******/ 	        (queryMap.hasOwnProperty(chunkId) ? '?' + queryMap[chunkId] : '')
 /******/ 	      );
 /******/ 	    };
 /******/ 	    __webpack_require__.e = function (chunkId) {
 /******/ 	      var result = oldLoadScript(chunkId);
 /******/ 	      return result.catch(function (error) {
-/******/ 	        var retries = countMap[chunkId] !== undefined ? countMap[chunkId] : 1;
+/******/ 	        var retries = countMap.hasOwnProperty(chunkId) ? countMap[chunkId] : 1;
 /******/ 	        if (retries < 1) {
 /******/ 	          var realSrc = oldGetScript(chunkId);
 /******/ 	          error.message =

--- a/test/integration/__snapshots__/test.ts.snap
+++ b/test/integration/__snapshots__/test.ts.snap
@@ -52,21 +52,19 @@ console.log('foo loaded!');
 /******/ 	  if (typeof __webpack_require__ !== 'undefined') {
 /******/ 	    var oldGetScript = __webpack_require__.u;
 /******/ 	    var oldLoadScript = __webpack_require__.e;
-/******/ 	    var queryMap = new Map();
-/******/ 	    var countMap = new Map();
+/******/ 	    var queryMap = {};
+/******/ 	    var countMap = {};
 /******/ 	    var getRetryDelay = function () {
 /******/ 	      return 0;
 /******/ 	    };
 /******/ 	    __webpack_require__.u = function (chunkId) {
 /******/ 	      var result = oldGetScript(chunkId);
-/******/ 	      return (
-/******/ 	        result + (queryMap.has(chunkId) ? '?' + queryMap.get(chunkId) : '')
-/******/ 	      );
+/******/ 	      return result + (!!queryMap[chunkId] ? '?' + queryMap[chunkId] : '');
 /******/ 	    };
 /******/ 	    __webpack_require__.e = function (chunkId) {
 /******/ 	      var result = oldLoadScript(chunkId);
 /******/ 	      return result.catch(function (error) {
-/******/ 	        var retries = countMap.has(chunkId) ? countMap.get(chunkId) : 1;
+/******/ 	        var retries = countMap[chunkId] !== undefined ? countMap[chunkId] : 1;
 /******/ 	        if (retries < 1) {
 /******/ 	          var realSrc = oldGetScript(chunkId);
 /******/ 	          error.message =
@@ -84,8 +82,8 @@ console.log('foo loaded!');
 /******/ 	          setTimeout(function () {
 /******/ 	            var retryAttemptString = '&retry-attempt=' + retryAttempt;
 /******/ 	            var cacheBust = 'cache-bust=true' + retryAttemptString;
-/******/ 	            queryMap.set(chunkId, cacheBust);
-/******/ 	            countMap.set(chunkId, retries - 1);
+/******/ 	            queryMap[chunkId] = cacheBust;
+/******/ 	            countMap[chunkId] = retries - 1;
 /******/ 	            resolve(__webpack_require__.e(chunkId));
 /******/ 	          }, getRetryDelay(retryAttempt));
 /******/ 	        });
@@ -166,21 +164,19 @@ console.log('foo loaded!');
 /******/ 	  if (typeof __webpack_require__ !== 'undefined') {
 /******/ 	    var oldGetScript = __webpack_require__.u;
 /******/ 	    var oldLoadScript = __webpack_require__.e;
-/******/ 	    var queryMap = new Map();
-/******/ 	    var countMap = new Map();
+/******/ 	    var queryMap = {};
+/******/ 	    var countMap = {};
 /******/ 	    var getRetryDelay = function (retryAttempt) {
 /******/ 	      return retryAttempt * 1000;
 /******/ 	    };
 /******/ 	    __webpack_require__.u = function (chunkId) {
 /******/ 	      var result = oldGetScript(chunkId);
-/******/ 	      return (
-/******/ 	        result + (queryMap.has(chunkId) ? '?' + queryMap.get(chunkId) : '')
-/******/ 	      );
+/******/ 	      return result + (!!queryMap[chunkId] ? '?' + queryMap[chunkId] : '');
 /******/ 	    };
 /******/ 	    __webpack_require__.e = function (chunkId) {
 /******/ 	      var result = oldLoadScript(chunkId);
 /******/ 	      return result.catch(function (error) {
-/******/ 	        var retries = countMap.has(chunkId) ? countMap.get(chunkId) : 1;
+/******/ 	        var retries = countMap[chunkId] !== undefined ? countMap[chunkId] : 1;
 /******/ 	        if (retries < 1) {
 /******/ 	          var realSrc = oldGetScript(chunkId);
 /******/ 	          error.message =
@@ -197,8 +193,8 @@ console.log('foo loaded!');
 /******/ 	          setTimeout(function () {
 /******/ 	            var retryAttemptString = '&retry-attempt=' + retryAttempt;
 /******/ 	            var cacheBust = 'cache-bust=true' + retryAttemptString;
-/******/ 	            queryMap.set(chunkId, cacheBust);
-/******/ 	            countMap.set(chunkId, retries - 1);
+/******/ 	            queryMap[chunkId] = cacheBust;
+/******/ 	            countMap[chunkId] = retries - 1;
 /******/ 	            resolve(__webpack_require__.e(chunkId));
 /******/ 	          }, getRetryDelay(retryAttempt));
 /******/ 	        });
@@ -279,21 +275,19 @@ console.log('foo loaded!');
 /******/ 	  if (typeof __webpack_require__ !== 'undefined') {
 /******/ 	    var oldGetScript = __webpack_require__.u;
 /******/ 	    var oldLoadScript = __webpack_require__.e;
-/******/ 	    var queryMap = new Map();
-/******/ 	    var countMap = new Map();
+/******/ 	    var queryMap = {};
+/******/ 	    var countMap = {};
 /******/ 	    var getRetryDelay = function () {
 /******/ 	      return 3000;
 /******/ 	    };
 /******/ 	    __webpack_require__.u = function (chunkId) {
 /******/ 	      var result = oldGetScript(chunkId);
-/******/ 	      return (
-/******/ 	        result + (queryMap.has(chunkId) ? '?' + queryMap.get(chunkId) : '')
-/******/ 	      );
+/******/ 	      return result + (!!queryMap[chunkId] ? '?' + queryMap[chunkId] : '');
 /******/ 	    };
 /******/ 	    __webpack_require__.e = function (chunkId) {
 /******/ 	      var result = oldLoadScript(chunkId);
 /******/ 	      return result.catch(function (error) {
-/******/ 	        var retries = countMap.has(chunkId) ? countMap.get(chunkId) : 1;
+/******/ 	        var retries = countMap[chunkId] !== undefined ? countMap[chunkId] : 1;
 /******/ 	        if (retries < 1) {
 /******/ 	          var realSrc = oldGetScript(chunkId);
 /******/ 	          error.message =
@@ -310,8 +304,8 @@ console.log('foo loaded!');
 /******/ 	          setTimeout(function () {
 /******/ 	            var retryAttemptString = '&retry-attempt=' + retryAttempt;
 /******/ 	            var cacheBust = 'cache-bust=true' + retryAttemptString;
-/******/ 	            queryMap.set(chunkId, cacheBust);
-/******/ 	            countMap.set(chunkId, retries - 1);
+/******/ 	            queryMap[chunkId] = cacheBust;
+/******/ 	            countMap[chunkId] = retries - 1;
 /******/ 	            resolve(__webpack_require__.e(chunkId));
 /******/ 	          }, getRetryDelay(retryAttempt));
 /******/ 	        });
@@ -392,21 +386,19 @@ console.log('foo loaded!');
 /******/ 	  if (typeof __webpack_require__ !== 'undefined') {
 /******/ 	    var oldGetScript = __webpack_require__.u;
 /******/ 	    var oldLoadScript = __webpack_require__.e;
-/******/ 	    var queryMap = new Map();
-/******/ 	    var countMap = new Map();
+/******/ 	    var queryMap = {};
+/******/ 	    var countMap = {};
 /******/ 	    var getRetryDelay = function () {
 /******/ 	      return 0;
 /******/ 	    };
 /******/ 	    __webpack_require__.u = function (chunkId) {
 /******/ 	      var result = oldGetScript(chunkId);
-/******/ 	      return (
-/******/ 	        result + (queryMap.has(chunkId) ? '?' + queryMap.get(chunkId) : '')
-/******/ 	      );
+/******/ 	      return result + (!!queryMap[chunkId] ? '?' + queryMap[chunkId] : '');
 /******/ 	    };
 /******/ 	    __webpack_require__.e = function (chunkId) {
 /******/ 	      var result = oldLoadScript(chunkId);
 /******/ 	      return result.catch(function (error) {
-/******/ 	        var retries = countMap.has(chunkId) ? countMap.get(chunkId) : 1;
+/******/ 	        var retries = countMap[chunkId] !== undefined ? countMap[chunkId] : 1;
 /******/ 	        if (retries < 1) {
 /******/ 	          var realSrc = oldGetScript(chunkId);
 /******/ 	          error.message =
@@ -423,8 +415,8 @@ console.log('foo loaded!');
 /******/ 	          setTimeout(function () {
 /******/ 	            var retryAttemptString = '&retry-attempt=' + retryAttempt;
 /******/ 	            var cacheBust = 'cache-bust=true' + retryAttemptString;
-/******/ 	            queryMap.set(chunkId, cacheBust);
-/******/ 	            countMap.set(chunkId, retries - 1);
+/******/ 	            queryMap[chunkId] = cacheBust;
+/******/ 	            countMap[chunkId] = retries - 1;
 /******/ 	            resolve(__webpack_require__.e(chunkId));
 /******/ 	          }, getRetryDelay(retryAttempt));
 /******/ 	        });
@@ -571,21 +563,19 @@ console.log('foo loaded!');
 /******/ 	  if (typeof __webpack_require__ !== 'undefined') {
 /******/ 	    var oldGetScript = __webpack_require__.u;
 /******/ 	    var oldLoadScript = __webpack_require__.e;
-/******/ 	    var queryMap = new Map();
-/******/ 	    var countMap = new Map();
+/******/ 	    var queryMap = {};
+/******/ 	    var countMap = {};
 /******/ 	    var getRetryDelay = function () {
 /******/ 	      return 0;
 /******/ 	    };
 /******/ 	    __webpack_require__.u = function (chunkId) {
 /******/ 	      var result = oldGetScript(chunkId);
-/******/ 	      return (
-/******/ 	        result + (queryMap.has(chunkId) ? '?' + queryMap.get(chunkId) : '')
-/******/ 	      );
+/******/ 	      return result + (!!queryMap[chunkId] ? '?' + queryMap[chunkId] : '');
 /******/ 	    };
 /******/ 	    __webpack_require__.e = function (chunkId) {
 /******/ 	      var result = oldLoadScript(chunkId);
 /******/ 	      return result.catch(function (error) {
-/******/ 	        var retries = countMap.has(chunkId) ? countMap.get(chunkId) : 1;
+/******/ 	        var retries = countMap[chunkId] !== undefined ? countMap[chunkId] : 1;
 /******/ 	        if (retries < 1) {
 /******/ 	          var realSrc = oldGetScript(chunkId);
 /******/ 	          error.message =
@@ -602,8 +592,8 @@ console.log('foo loaded!');
 /******/ 	          setTimeout(function () {
 /******/ 	            var retryAttemptString = '&retry-attempt=' + retryAttempt;
 /******/ 	            var cacheBust = 'cache-bust=true' + retryAttemptString;
-/******/ 	            queryMap.set(chunkId, cacheBust);
-/******/ 	            countMap.set(chunkId, retries - 1);
+/******/ 	            queryMap[chunkId] = cacheBust;
+/******/ 	            countMap[chunkId] = retries - 1;
 /******/ 	            resolve(__webpack_require__.e(chunkId));
 /******/ 	          }, getRetryDelay(retryAttempt));
 /******/ 	        });


### PR DESCRIPTION
Hello @mattlewis92 !

This change gets rid of the usage of Map to make the plugin es5 compatible.

A simple JS object has the same effect and it allows us to use the plugin in older browsers that are not es6 compatible, otherwise it just fails to parse the first chunk.
