### PR TITLE
Move prettier from dependency to devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5739,7 +5739,8 @@
     "prettier": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
-      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew=="
+      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "dev": true
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "jest": "^27.5.1",
     "memory-fs": "^0.5.0",
     "nodemon": "^2.0.16",
+    "prettier": "^2.6.2",
     "pretty-quick": "^3.1.3",
     "ts-jest": "^27.1.4",
     "ts-loader": "^9.3.0",
@@ -61,9 +62,7 @@
     "url": "https://github.com/mattlewis92/webpack-retry-chunk-load-plugin/issues"
   },
   "homepage": "https://github.com/mattlewis92/webpack-retry-chunk-load-plugin#readme",
-  "dependencies": {
-    "prettier": "^2.6.2"
-  },
+  "dependencies": {},
   "files": [
     "dist"
   ]


### PR DESCRIPTION
Seems prettier was added as a dependency of this module, whereas it is only required for development purposes. As a result the [reported bundle size](https://bundlephobia.com/package/webpack-retry-chunk-load-plugin@3.1.1) might scare people off due to the impact on download time.

This PR moves the prettier dependency to the devDependency block instead