### PR TITLE
logged all tried URL after all retries chunk is not loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ plugins: [
     lastResortScript: "window.location.href='/500.html';",
     // optional value to be executed in the browser context if after all retries chunk is not loaded.
     // if set - error will be returned to the chunk loader with url which tried.
-    allTriedUrl: false,
+    allLogUrl: false,
   }),
 ];
 ```

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ plugins: [
     // optional code to be executed in the browser context if after all retries chunk is not loaded.
     // if not set - nothing will happen and error will be returned to the chunk loader.
     lastResortScript: "window.location.href='/500.html';",
+    // optional value to be executed in the browser context if after all retries chunk is not loaded.
+    // if set - error will be returned to the chunk loader with url which tried.
+    allTriedUrl: false,
   }),
 ];
 ```

--- a/test/integration/test.ts
+++ b/test/integration/test.ts
@@ -9,6 +9,8 @@ const cases: (RetryChunkLoadPluginOptions | undefined)[] = [
   { chunks: [] },
   { chunks: ['main'] },
   { chunks: ['main'], retryDelay: 3000 },
+
+  { chunks: ['main'], allLogUrl: true },
   {
     chunks: ['main'],
     retryDelay: 'function(retryAttempt) { return retryAttempt * 1000 }',


### PR DESCRIPTION
we have added this Plugin to our project after all retried the chunk(module) load it got fail but we need all the tried URL should be logged

optional value to be executed in the browser context if after all retries chunk is not loaded