### PR TITLE
Pass through all arguments of ensureChunk()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -81,7 +81,7 @@ export class RetryChunkLoadPlugin {
               return result + (queryMap.hasOwnProperty(chunkId) ? '?' + queryMap[chunkId]  : '');
             };
             ${RuntimeGlobals.ensureChunk} = function(chunkId){
-              var result = oldLoadScript(chunkId);
+              var result = oldLoadScript.apply(undefined, arguments);
               return result.catch(function(error){
                 var retries = countMap.hasOwnProperty(chunkId) ? countMap[chunkId] : ${maxRetries};
                 if (retries < 1) {


### PR DESCRIPTION
Based on a reading of [the implementation of `ensureChunk()` in the webpack source](https://github.com/webpack/webpack/blob/cd8b2aa236d9e3420a37655c3554818eda1523fa/lib/runtime/EnsureChunkRuntimeModule.js#L39), it seems to support an optional `fetchPriority` parameter.  As `webpack-retry-chunk-loader` is currently implemented, however, when `ensureChunk()` is replaced with a new function that calls the original version, this parameter is not passed through.

This PR proposes a modification that passes all arguments through.  Javascript features such as [`arguments`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments) and [`function.apply()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply) are proposed to ensure maximum browser compatibility.